### PR TITLE
Bioshock: Fixed near impossible final boss

### DIFF
--- a/stripper/maps/ze_bioshock_v5_6.cfg
+++ b/stripper/maps/ze_bioshock_v5_6.cfg
@@ -7,7 +7,26 @@
 ; | |\/| | |  | | |  | || | |  __|   \   /
 ; | |  | | |__| | |__| || |_| |       | |
 ; |_|  |_|\____/|_____/_____|_|       |_|
-; Generated 0 modify blocks.
+; Generated 1 modify blocks.
+modify:
+{
+	match:
+	{
+		"origin" "144 -11176 8384"
+		"targetname" "HARD_ONLY_TRIGGER"
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"OnStartTouch" "fontaine_stage1_hp,Add,90,0,-1"
+		"OnStartTouch" "fontaine_stage2_hp,Add,45,0,-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "fontaine_stage1_hp,Add,22,0,-1"
+		"OnStartTouch" "fontaine_stage2_hp,Add,12,0,-1"
+	}
+}
 
 ;  ______ _____ _   _______ ______ _____
 ; |  ____|_   _| | |__   __|  ____|  __ \


### PR DESCRIPTION
Final boss has too much health for larger/less able teams who reach. This reduces his health by ~75%. Makes the boss easy for small teams, which isnt problematic, and much easier for larger teams, which is necessary.