### PR TITLE
ze_bioshock bugfixes to stage4+5

### DIFF
--- a/stripper/maps/ze_bioshock_v6.cfg
+++ b/stripper/maps/ze_bioshock_v6.cfg
@@ -4,7 +4,7 @@
 ; | |\/| | |  | | |  | || | |  __|   \   /
 ; | |  | | |__| | |__| || |_| |       | |
 ; |_|  |_|\____/|_____/_____|_|       |_|
-; Generated 4 modify blocks.
+; Generated 10 modify blocks.
 
 ;---------------------------------------------------------
 ;Fixes Chapter 4 Easy difficulty also triggering hard mode
@@ -71,5 +71,117 @@ modify:
 	insert:
 	{
 		"OnTrigger" "template_plasmid_gravity,Kill,,0,-1"
+	}
+}
+
+;------------------------------------
+; 1999 Mode fixed boss tp not working
+;------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "columbia_alt_boss_door"
+		"origin" "-248 936 -11528"
+		"classname" "func_movelinear"
+	}
+	insert:
+	{
+		"OnFullyClosed" "columbia_alt_boss_teleport,Enable,,1,-1"
+	}
+}
+
+;----------------------------------------------
+; BELOW HERE NECESSARY BALANCE FIXES BEFORE 6_1
+;----------------------------------------------
+;---------------------------
+; Increase Bouncer knockback
+;---------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_knock_back"
+	}
+	replace:
+	{
+		"speed" "125"
+	}
+}
+
+
+;-----------------------------------------------
+; Stage 4 - increase time before boss cage break
+;-----------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "hephaestus_boss_exit_trigger"
+		"origin" "6784 -12424 -1488"
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"OnStartTouch" "hephaestus_boss_cage_door,Break,,5,1"
+	}
+	insert:
+	{
+		"OnStartTouch" "hephaestus_boss_cage_door,Break,,10,1"
+	}
+}
+
+;-------------------------------------------------------------
+; Stage 4 - Fix teleport timings causing nuke to fail at spawn
+;-------------------------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "r4_finish_path5"
+		"classname" "path_track"
+	}
+	insert:
+	{
+		"OnPass" "hephaestus_teleport_1,Enable,,1,-1"
+	}
+}
+
+;----------------------------------------------------------------------------
+; 1999 Few misc adjustments I (DormantLemon) didn't feel could wait until 6_1
+;----------------------------------------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "level_case"
+		"classname" "logic_case"
+	}
+	insert:
+	{
+		"OnCase06" "plasmid_counter_electro,SetValue,4,10,-1"
+		"OnCase06" "welcome_boss_bomb_freezer,Kill,,0,-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "columbia_island_alt_trigger"
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"OnTrigger" "ui_timer,SetValue,30,0.01,-1"
+		"OnTrigger" "columbia_alt_island_door,StartForward,,30,-1"
+		"OnTrigger" "columbia_alt_island_door,Stop,,31,-1"
+		"OnTrigger" "columbia_alt_island_door,Kill,,31.01,-1"
+	}
+	insert:
+	{
+		"OnTrigger" "ui_timer,SetValue,20,0.01,-1"
+		"OnTrigger" "columbia_alt_island_door,StartForward,,20,-1"
+		"OnTrigger" "columbia_alt_island_door,Stop,,21,-1"
+		"OnTrigger" "columbia_alt_island_door,Kill,,21.01,-1"
 	}
 }


### PR DESCRIPTION
In light of recent playthroughs, ze_bioshock_v6 revised fixes. 
- Fix for fatal lack of teleport 1999
- Fixed nuke failing near spawn on Stage 4
- A few necessary balance adjustments that couldn't wait until a new release