### PR TITLE
ze_bioshock_v6_1 fixes ahead of event

### DIFF
--- a/stripper/maps/ze_bioshock_v6_1.cfg
+++ b/stripper/maps/ze_bioshock_v6_1.cfg
@@ -1,0 +1,166 @@
+;  __  __  ____  _____ _____ ________     __
+; |  \/  |/ __ \|  __ \_   _|  ____\ \   / /
+; | \  / | |  | | |  | || | | |__   \ \_/ /
+; | |\/| | |  | | |  | || | |  __|   \   /
+; | |  | | |__| | |__| || |_| |       | |
+; |_|  |_|\____/|_____/_____|_|       |_|
+; Generated 10 modify blocks.
+
+;-------------------
+;Reduced dash power
+;-------------------
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_rush_push"
+	}
+	replace:
+	{
+		"speed" "250"
+	}
+}
+;---------------------------------------------------------
+;Increase bouncer knockback
+;---------------------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_physbox"
+		"origin" "-9676 -3136 9148"
+	}
+	delete:
+	{
+		"OnHealthChanged" "big_daddy_knock_back,Disable,,0.01,-1"
+	}
+	insert:
+	{
+		"OnHealthChanged" "big_daddy_knock_back,Disable,,0.02,-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_physbox"
+		"origin" "-9716 -3136 9148"
+	}
+	delete:
+	{
+		"OnHealthChanged" "big_daddy_knock_forward,Disable,,0.01,-1"
+	}
+	insert:
+	{
+		"OnHealthChanged" "big_daddy_knock_forward,Disable,,0.02,-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_physbox"
+		"origin" "-9696 -3156 9148"
+	}
+	delete:
+	{
+		"OnHealthChanged" "big_daddy_knock_left,Disable,,0.01,-1"
+	}
+	insert:
+	{
+		"OnHealthChanged" "big_daddy_knock_left,Disable,,0.02,-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "big_daddy_physbox"
+		"origin" "-9696 -3116 9148"
+	}
+	delete:
+	{
+		"OnHealthChanged" "big_daddy_knock_right,Disable,,0.01,-1"
+	}
+	insert:
+	{
+		"OnHealthChanged" "big_daddy_knock_right,Disable,,0.02,-1"
+	}
+}
+;-----------------------------
+;Removed Bouncer from easy
+;-----------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "difficulty_case"
+	}
+	insert:
+	{
+		"OnCase01" "big_daddy_wep,Kill,,8,-1"
+	}
+}
+;----------------------------------------------
+;Fix the broken teleport (an errant parentname)
+;----------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "columbia_alt_boss_teleport"
+	}
+	replace:
+	{
+		"parentname" "null_notempty"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "columbia_alt_boss_door"
+		"origin" "-248 936 -11528"
+	}
+	delete:
+	{
+		"OnFullyClosed" "columbia_alt_boss_teleport,Enable,,0,-1"
+	}
+	insert:
+	{
+		"OnFullyClosed" "columbia_alt_boss_teleport,Enable,,0.05,-1"
+	}
+}
+;--------------------------------------------
+;Set alt. end trigger to start 1999 correctly
+;--------------------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "win_trigger"
+		"origin" "-12432 -13040 -7424"
+	}
+	delete:
+	{
+		"OnTrigger" "level_counter,SetValueNoFire,1,0,1"
+	}
+	insert:
+	{
+		"OnTrigger" "level_counter,SetValueNoFire,5,0,1"
+	}
+}
+;----------------------------------
+;Secrets obtained persistance fix
+;----------------------------------
+modify:
+{
+	match:
+	{
+		"targetname" "secret_counter_pre"
+	}
+	insert:
+	{
+		"OnGetValue" "secret_case,InValue,,0,-1"
+	}
+}


### PR DESCRIPTION
Fixes to:
a teleport in 1999
bouncer item nerfs, 
Found secrets lack persistence
Alt. end fails to enable 1999